### PR TITLE
feature: Add servicemonitor capabilities

### DIFF
--- a/helm/reddit-exporter/Chart.yaml
+++ b/helm/reddit-exporter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.9.1"
 description: A Helm chart for Kubernetes
 name: reddit-exporter
-version: 0.9.2
+version: 0.10.0

--- a/helm/reddit-exporter/templates/servicemonitor.yaml
+++ b/helm/reddit-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{include "reddit-exporter.fullname" .}}
+  labels:
+    app.kubernetes.io/name: {{ include "reddit-exporter.name" . }}
+    helm.sh/chart: {{ include "reddit-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  jobLabel: reddit-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "reddit-exporter.name" . }}
+      helm.sh/chart: {{ include "reddit-exporter.chart" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+  endpoints:
+    - port: http
+      interval: 30s
+{{- end}}

--- a/helm/reddit-exporter/values.yaml
+++ b/helm/reddit-exporter/values.yaml
@@ -47,6 +47,10 @@ tolerations: []
 
 affinity: {}
 
+serviceMonitor:
+  # Deploy a prometheus service monitor
+  enabled: false
+
 verbose: false
 regexMatches: false
 regexMatchesFormat: yaml


### PR DESCRIPTION
Hi.

I've added an option to your Helm Chart to automatically deploy a prometheus operator's `serviceMonitor`.
It will automatically add you exporter a target for prom.

This option is commonly found in charts having an exporter.